### PR TITLE
Sincronizar develop con cambios de la release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+Todos los cambios notables en este proyecto serán documentados en este archivo.
+
+El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/),
+y este proyecto adhiere a [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-04-15
+
+### Añadido
+- Implementación inicial del grafo conversacional con LangGraph
+- API REST básica con FastAPI
+- Extractores de datos simples
+- Validadores para información de lead (teléfono, email, documento)
+- Pruebas unitarias para utilidades
+- Estructura del proyecto para desarrollo incremental
+- Cumplimiento con la Ley 29733 de protección de datos
+
+### Cambios
+- Primera versión del MVP


### PR DESCRIPTION
Esta PR sincroniza la rama develop con los cambios realizados en main tras la release 0.1.0.

De acuerdo con GitFlow, después de una release, los cambios realizados en main (como la adición del CHANGELOG) deben ser incorporados de vuelta a develop para mantener ambas ramas sincronizadas.

No hay cambios funcionales, solo documentación.