### PR TITLE
Implementar extractor de números telefónicos peruanos

### DIFF
--- a/src/utils/extractors.py
+++ b/src/utils/extractors.py
@@ -3,6 +3,9 @@
 This module contains functions to extract structured data from natural language responses.
 """
 
+import re
+from src.utils.validators import validate_phone_number
+
 # These are placeholder functions for Phase 1
 # They will be enhanced with NLP capabilities in Phase 2
 
@@ -35,9 +38,39 @@ def extract_location(text):
     return None
 
 def extract_phone_number(text):
-    """Extract phone number from text."""
-    # This will be implemented in Phase 2
-    # Will use regex patterns for Peruvian phone numbers
+    """Extract phone number from text.
+    
+    Identifies and extracts Peruvian phone numbers in various formats:
+    - 9XXXXXXXX (9 digits starting with 9)
+    - +519XXXXXXXX (with country code)
+    - 51-9XXXXXXXX (with country code and hyphen)
+    - 51 9XX XXX XXX (with spaces)
+    
+    Args:
+        text (str): Text containing potential phone numbers
+        
+    Returns:
+        str or None: Extracted phone number if found, None otherwise
+    """
+    if not text:
+        return None
+    
+    # Common patterns for Peruvian phone numbers
+    patterns = [
+        r'\b9\d{8}\b',                       # 9XXXXXXXX
+        r'(?:\+51|51)[- ]?9[- ]?\d{8}\b',    # +519XXXXXXXX or 519XXXXXXXX with optional spaces/hyphens
+        r'\b51[- ]?9[- ]?\d{2}[- ]?\d{3}[- ]?\d{3}\b'  # 51 9XX XXX XXX with various separators
+    ]
+    
+    # Try each pattern
+    for pattern in patterns:
+        matches = re.findall(pattern, text)
+        if matches:
+            # Clean up the first match and validate
+            candidate = matches[0]
+            if validate_phone_number(candidate):
+                return candidate
+    
     return None
 
 def extract_consent(text):

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,7 +1,7 @@
 """Tests for data extraction utilities."""
 
 import pytest
-from src.utils.extractors import extract_property_type, extract_consent
+from src.utils.extractors import extract_property_type, extract_consent, extract_phone_number
 
 def test_extract_property_type():
     """Test extraction of property types."""
@@ -35,3 +35,30 @@ def test_extract_consent():
     # Test negative or unclear responses
     assert extract_consent("No estoy seguro") == False
     assert extract_consent("¿Qué implica esto?") == False
+
+def test_extract_phone_number():
+    """Test extraction of Peruvian phone numbers."""
+    # Test basic 9-digit format
+    assert extract_phone_number("Mi número es 987654321") == "987654321"
+    
+    # Test with country code
+    assert extract_phone_number("Me puedes llamar al +51987654321") == "+51987654321"
+    assert extract_phone_number("Contacto: 51-987654321") == "51-987654321"
+    
+    # Test with spaces
+    assert extract_phone_number("Mi cel es 51 987 654 321") == "51 987 654 321"
+    
+    # Test within a sentence
+    assert extract_phone_number("Para coordinar llámame al 987654321 en cualquier momento") == "987654321"
+    
+    # Test multiple numbers (should return the first valid one)
+    assert extract_phone_number("Tengo dos números: 987654321 y 987123456") == "987654321"
+    
+    # Test invalid formats
+    assert extract_phone_number("Mi número fijo es 2137890") is None  # Not starting with 9
+    assert extract_phone_number("12345678") is None  # Not starting with 9
+    assert extract_phone_number("Texto sin número") is None  # No phone number
+    
+    # Test empty input
+    assert extract_phone_number("") is None
+    assert extract_phone_number(None) is None


### PR DESCRIPTION
## Descripción
Esta PR implementa un extractor de números telefónicos peruanos con expresiones regulares, resolviendo el issue #4.

## Cambios realizados
- Se implementó la función `extract_phone_number` en `src/utils/extractors.py` que detecta números telefónicos peruanos con varios formatos:
  - 9XXXXXXXX
  - +519XXXXXXXX
  - 51-9XXXXXXXX
  - 51 9XX XXX XXX (con espacios)
- Se agregaron pruebas unitarias completas en `tests/test_extractors.py`
- La función utiliza el validador `validate_phone_number` existente para verificar que los números extraídos sean válidos

## Características
- Extrae números telefónicos incluso cuando están en medio de oraciones
- Maneja múltiples formatos con/sin código de país
- Funciona con diferentes separadores (espacios, guiones)
- Retorna `None` cuando no encuentra números válidos

## Pruebas
- Se agregaron 8 casos de prueba diferentes para cubrir todos los escenarios

Fixes #4